### PR TITLE
Fixed CSS bug

### DIFF
--- a/simpli/static/resources/theme.css
+++ b/simpli/static/resources/theme.css
@@ -187,7 +187,7 @@ h3 {
   width: 20px;
 }
 
-button.close, .library-modal-header, .library-modal-footer {
+#library-parent button.close, .library-modal-header, .library-modal-footer {
   display: none;
 }
 

--- a/simpli/static/resources/theme.scss
+++ b/simpli/static/resources/theme.scss
@@ -220,7 +220,7 @@ h3 {
   }
 }
 
-button.close, .library-modal-header, .library-modal-footer {
+#library-parent button.close, .library-modal-header, .library-modal-footer {
   display: none;
 }
 


### PR DESCRIPTION
Basically this was an overly permissive CSS selector which would hide close buttons not just on the main Simpli modal dialog, but all modal dialogs in the notebook.